### PR TITLE
Add .turbo ignore to stop cache missing when used in tandem with turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ types/
 docs/
 
 dist/
+.turbo


### PR DESCRIPTION
This is for including the types repo as a submodule in a larger system