### PR TITLE
Add Boolean and Number types

### DIFF
--- a/src/constants/TokenTypes.ts
+++ b/src/constants/TokenTypes.ts
@@ -22,6 +22,8 @@ export enum TokenTypes {
   DIMENSION = 'dimension',
   BORDER = 'border',
   ASSET = 'asset',
+  BOOLEAN = 'boolean',
+  NUMBER = 'number',
 }
 
 export type TokenTypesUnion = `${TokenTypes}`;

--- a/src/types/tokens/SingleBooleanToken.ts
+++ b/src/types/tokens/SingleBooleanToken.ts
@@ -1,0 +1,9 @@
+import { TokenTypes } from '../../constants/TokenTypes.js';
+import { SingleGenericToken } from './SingleGenericToken.js';
+
+export type SingleBooleanToken<Named extends boolean = true, P = unknown> = SingleGenericToken<
+  TokenTypes.BOOLEAN,
+  'true' | 'false',
+  Named,
+  P
+>;

--- a/src/types/tokens/SingleNumberToken.ts
+++ b/src/types/tokens/SingleNumberToken.ts
@@ -1,0 +1,9 @@
+import { TokenTypes } from '../../constants/TokenTypes.js';
+import { SingleGenericToken } from './SingleGenericToken.js';
+
+export type SingleNumberToken<Named extends boolean = true, P = unknown> = SingleGenericToken<
+  TokenTypes.NUMBER,
+  string,
+  Named,
+  P
+>;

--- a/src/types/tokens/SingleToken.ts
+++ b/src/types/tokens/SingleToken.ts
@@ -20,6 +20,8 @@ import { SingleDimensionToken } from './SingleDimensionToken.js';
 import { SingleBorderToken } from './SingleBorderToken.js';
 import { SingleAssetToken } from './SingleAssetToken.js';
 import { SingleSizingToken } from './SingleSizingToken.js';
+import { SingleBooleanToken } from './SingleBooleanToken.js';
+import { SingleNumberToken } from './SingleNumberToken.js';
 
 export type SingleToken<Named extends boolean = true, P = unknown> =
   | SingleColorToken<Named, P>
@@ -41,7 +43,8 @@ export type SingleToken<Named extends boolean = true, P = unknown> =
   | SingleOtherToken<Named, P>
   | SingleBorderToken<Named, P>
   | SingleCompositionToken<Named, P>
-  | SingleCompositionToken<Named, P>
   | SingleDimensionToken<Named, P>
   | SingleSizingToken<Named, P>
-  | SingleAssetToken<Named, P>;
+  | SingleAssetToken<Named, P>
+  | SingleBooleanToken<Named, P>
+  | SingleNumberToken<Named, P>


### PR DESCRIPTION
It seems Boolean and Number were missing from declaration.
Also, I fixed a duplication within SingleToken.ts

Probably, linting and formatting are off.
I could not run the pre-commit hook for a reason I can't explain.