### PR TITLE
Remove explicit types which causes unnecessary build errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "resolveJsonModule": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-    "types": ["node"],
     "esModuleInterop": true,
     "outDir": "dist"
   },


### PR DESCRIPTION
This is currently causing build errors in the monorepo from the explicit types in the tsconfig. The compilation of the code should work regardless of this change